### PR TITLE
Updated for newest version of the TypeScript Cookiecutter

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,11 +44,12 @@
     "dev": "webpack-cli serve --inline --hot --progress --content-base ./mock --open -o ./mock"
   },
   "dependencies": {
-    "@jupyter-widgets/base": "^4.0.0"
+    "@jupyter-widgets/base": "^1.1.10 || ^2 || ^3 || ^4 || ^5 || ^6"
   },
   "devDependencies": {
-    "@phosphor/application": "^1.6.0",
-    "@phosphor/widgets": "^1.6.0",
+    "@lumino/application": "^1.6.0",
+    "@lumino/widgets": "^1.6.0",
+    "@jupyter-widgets/base-manager": "^1.0.2",
     "@tsconfig/svelte": "^1.0.10",
     "@types/node": "^10.11.6",
     "@types/webpack-env": "^1.13.6",
@@ -74,9 +75,16 @@
     "typescript": "^4.2.4",
     "webpack": "^5.20.1",
     "webpack-cli": "^4.4.0",
-    "webpack-dev-server": "^3.11.2"
+    "webpack-dev-server": "^4.15.0"
   },
-  "jupyterlab": {
-    "extension": "lib/plugin"
+ "jupyterlab": {
+    "extension": "lib/plugin",
+    "outputDir": "jupyter_bbox_widget/labextension/",
+    "sharedPackages": {
+      "@jupyter-widgets/base": {
+        "bundled": false,
+        "singleton": true
+      }
+    }
   }
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,9 +1,9 @@
 // Copyright (c) gereleth
 // Distributed under the terms of the Modified BSD License.
 
-import type { Application, IPlugin } from '@phosphor/application';
+import type { Application, IPlugin } from '@lumino/application';
 
-import type { Widget } from '@phosphor/widgets';
+import type { Widget } from '@lumino/widgets';
 
 import { IJupyterWidgetRegistry } from '@jupyter-widgets/base';
 


### PR DESCRIPTION
Fixed it for using Lumino and newer updates to the TypeScript Cookiecutter [template](https://github.com/jupyter-widgets/widget-ts-cookiecutter/commit/82f4a6c9ecf5f775a63e48ef3dc567e835300783). As seen in the behavior in #15. 