### PR TITLE
Fix bbox edits in marimo

### DIFF
--- a/svelte/BBoxWidget.svelte
+++ b/svelte/BBoxWidget.svelte
@@ -135,8 +135,9 @@
     // don't know why
     // Use a workaround from
     // https://github.com/jupyter-widgets/ipywidgets/issues/2916
+    const updatedBBoxes = $bboxes.map((bbox) => ({ ...bbox }));
     model.set("bboxes", [], { silent: true });
-    model.set("bboxes", [...$bboxes]);
+    model.set("bboxes", updatedBBoxes);
     model.save_changes();
   }
 


### PR DESCRIPTION
Fixes #31.

This PR improves jupyter-bbox-widget compatibility with current marimo versions. The original image-rendering symptom from #31 appears fixed in current marimo; during compatibility testing, the remaining issue was that drawing a bbox could reset the widget state.

With current marimo, the widget image renders, but bbox edits can reset because marimo applies the temporary `bboxes=[]` update that Jupyter suppresses via `{ silent: true }`. This patch snapshots the bbox list before that temporary clear, preserving the intended final update.

Tested:
- `npm run build`
- marimo 0.23.6 smoke: image renders; drag creates a new bbox; count stays `2 -> 3`; coordinates appear in output data; Submit/Skip callbacks reach Python
- JupyterLab smoke: image renders; drag creates a new bbox; count stays `2 -> 3`; no Jupyter browser console errors